### PR TITLE
Use Unicode-emileys and replace text

### DIFF
--- a/assets/javascripts/discourse/widgets/topic-list.js.es6
+++ b/assets/javascripts/discourse/widgets/topic-list.js.es6
@@ -7,8 +7,12 @@ createWidget('layouts-topic-list-item', {
   tagName: 'li',
 
   html(attrs) {
-    const title = attrs.topic.get('fancyTitle');
-    return h('span', title);
+    const uni_title = attrs.topic.get('unicode_title');
+    const title = uni_title ? uni_title : attrs.topic.get('title');
+
+    return h('span',
+      title.replace(/<[^>]*>/g, '').replace(/:[a-zA-Z]*:/g, '')
+    );
   },
 
   click() {


### PR DESCRIPTION
I can't get render with markdown or other solution to work, so this should:
- Render smileys as unicode
- Replace HTML-blocks
- Replace `:value:`